### PR TITLE
Batch support

### DIFF
--- a/configs/DataConfig.py
+++ b/configs/DataConfig.py
@@ -7,7 +7,7 @@ class DataConfig:
     data_dir: str = "dataset_all_processed"
     # How to load each sample
     mode: str = "pickle"
-    batch_size: int = 1
+    batch_size: int = 4
     # Size of the validation set (as a fraction of the training set)
     validation_split: float = 0.1
     # Size of the test set (as a fraction of the whole dataset, remaining is used for training)

--- a/configs/GeneratorConfig.py
+++ b/configs/GeneratorConfig.py
@@ -16,7 +16,7 @@ class GeneratorConfig:
     # Dimension of output edge features
     edge_out_fts: int = 32
     # Number of attention heads for node update layer
-    num_heads_node: int = 1
+    num_heads_node: int = 2
     # Number of attention heads for graph update layer
     num_heads_graph: int = 5
     # Number of nodes in the graph

--- a/configs/TrainerConfig.py
+++ b/configs/TrainerConfig.py
@@ -4,16 +4,18 @@ from dataclasses import dataclass, asdict
 @dataclass
 class TrainerConfig:
     # Learning rate
-    lr: float = 0.001  # 0.0025  # previously 0.0005
+    lr: float = 0.002  # 0.0025  # previously 0.0005
     # https://pytorch-lightning.readthedocs.io/en/stable/advanced/training_tricks.html#gradient-clipping
     is_clip_grads: bool = False
-    gradient_clip_val: float = 10.0
+    gradient_clip_val: float = 6.0
     gradient_clip_algorithm: str = "norm"
 
     track_grad_norm: int = 2
     # Weight decay / L2 Regularization
     weight_decay: float = 0.0005
-    num_epochs: int = 20
+    # num_epochs: int = 20
+    pretrain_epochs: int = 30
+    gan_epochs: int = 5
 
     def dict(self):
         return {k: str(v) for k, v in asdict(self).items()}

--- a/configs/TrainerConfig.py
+++ b/configs/TrainerConfig.py
@@ -7,15 +7,15 @@ class TrainerConfig:
     lr: float = 0.002  # 0.0025  # previously 0.0005
     # https://pytorch-lightning.readthedocs.io/en/stable/advanced/training_tricks.html#gradient-clipping
     is_clip_grads: bool = False
-    gradient_clip_val: float = 6.0
+    gradient_clip_val: float = 4.0
     gradient_clip_algorithm: str = "norm"
 
     track_grad_norm: int = 2
     # Weight decay / L2 Regularization
     weight_decay: float = 0.0005
     # num_epochs: int = 20
-    pretrain_epochs: int = 30
-    gan_epochs: int = 5
+    pretrain_epochs: int = 30  # after 18 it overfits
+    gan_epochs: int = 0
 
     def dict(self):
         return {k: str(v) for k, v in asdict(self).items()}

--- a/data_modules/data_helpers.py
+++ b/data_modules/data_helpers.py
@@ -11,7 +11,7 @@ def collate_fn(
     batch_index_shift = torch.tensor([0])
     temporal_indices_shifts = torch.tensor([])
 
-    batch_edges_collated = torch.tensor([])
+    batch_edges_collated = torch.tensor([], dtype=torch.long)
     batch_node_fts_collated = torch.tensor([])
     batch_edge_fts_collated = torch.tensor([])
     batch_graph_fts_collated = torch.tensor([])
@@ -20,7 +20,7 @@ def collate_fn(
         b_index_shift = batch_index_shift[-1]
 
         temporal_index_shift = torch.tensor([0])
-        temporal_edges_collated = torch.tensor([])
+        temporal_edges_collated = torch.tensor([], dtype=torch.long)
         temporal_node_fts_collated = torch.tensor([])
         temporal_edge_fts_collated = torch.tensor([])
         temporal_graph_fts_collated = torch.tensor([])
@@ -86,8 +86,8 @@ def collate_fn(
         )
 
     return [
-        batch_index_shift,
-        temporal_indices_shifts,
+        # batch_index_shift,
+        # temporal_indices_shifts,
         batch_edges_collated,
         batch_node_fts_collated,
         batch_edge_fts_collated,

--- a/data_modules/data_helpers.py
+++ b/data_modules/data_helpers.py
@@ -1,0 +1,104 @@
+import torch
+import pickle
+import os
+from typing import List, Tuple
+
+
+def collate_fn(
+    batch: List[Tuple[List[List[torch.Tensor]], torch.Tensor]]
+) -> List[torch.Tensor]:
+    target_collated = torch.tensor([])
+    batch_index_shift = torch.tensor([0])
+    temporal_indices_shifts = torch.tensor([])
+
+    batch_edges_collated = torch.tensor([])
+    batch_node_fts_collated = torch.tensor([])
+    batch_edge_fts_collated = torch.tensor([])
+    batch_graph_fts_collated = torch.tensor([])
+
+    for i, (sequence, target) in enumerate(batch):
+        b_index_shift = batch_index_shift[-1]
+
+        temporal_index_shift = torch.tensor([0])
+        temporal_edges_collated = torch.tensor([])
+        temporal_node_fts_collated = torch.tensor([])
+        temporal_edge_fts_collated = torch.tensor([])
+        temporal_graph_fts_collated = torch.tensor([])
+
+        # each element in the sequence a list of tensors
+        # element = [edges, node_fts, edge_fts, graph_fts, adj]
+        for element in sequence:
+            t_index_shift = temporal_index_shift[-1]
+            num_nodes_in_current_graph = element[1].shape[0]
+            # shift the node index in the edges
+            temporal_edges = element[0] + t_index_shift
+
+            temporal_edges_collated = torch.cat(
+                (temporal_edges_collated, temporal_edges), dim=1
+            )
+            # concatenate the node features
+            temporal_node_fts_collated = torch.cat(
+                (temporal_node_fts_collated, element[1]), dim=0
+            )
+            # concatenate the edge features
+            temporal_edge_fts_collated = torch.cat(
+                (temporal_edge_fts_collated, element[2]), dim=0
+            )
+            # concatenate the graph features
+            temporal_graph_fts_collated = torch.cat(
+                (temporal_graph_fts_collated, element[3]), dim=0
+            )
+            # update the index shift
+            temporal_index_shift = torch.cat(
+                (
+                    temporal_index_shift,
+                    torch.tensor([t_index_shift + num_nodes_in_current_graph]),
+                )
+            )
+
+        target_collated = torch.cat((target_collated, target), dim=0)
+
+        temporal_indices_shifts = torch.cat(
+            (temporal_indices_shifts, temporal_index_shift), dim=0
+        )
+
+        # shift the node index in the edges
+        batch_edges = temporal_edges_collated + b_index_shift
+        batch_edges_collated = torch.cat((batch_edges_collated, batch_edges), dim=1)
+        # concatenate the node features
+        batch_node_fts_collated = torch.cat(
+            (batch_node_fts_collated, temporal_node_fts_collated), dim=0
+        )
+        # concatenate the edge features
+        batch_edge_fts_collated = torch.cat(
+            (batch_edge_fts_collated, temporal_edge_fts_collated), dim=0
+        )
+        # concatenate the graph features
+        batch_graph_fts_collated = torch.cat(
+            (batch_graph_fts_collated, temporal_graph_fts_collated), dim=0
+        )
+        # update the index shift
+        batch_index_shift = torch.cat(
+            (
+                batch_index_shift,
+                torch.tensor([batch_index_shift[-1] + temporal_index_shift[-1]]),
+            )
+        )
+
+    return [
+        batch_index_shift,
+        temporal_indices_shifts,
+        batch_edges_collated,
+        batch_node_fts_collated,
+        batch_edge_fts_collated,
+        batch_graph_fts_collated,
+        target_collated,
+    ]
+
+
+def load_all_pickle(data_dir):
+    data = []
+    for i in range(len(os.listdir(data_dir))):
+        with open(data_dir + "/" + str(i) + ".pickle", "rb") as pickle_file:
+            data.append(pickle.load(pickle_file))
+    return data

--- a/data_modules/data_module.py
+++ b/data_modules/data_module.py
@@ -9,10 +9,6 @@ from .data_helpers import *
 
 
 class GraphDataModule(pl.LightningDataModule):
-    """
-    DataModule used for semantic segmentation in geometric generalization project
-    """
-
     def __init__(
         self,
         data_config: DataConfig,

--- a/data_modules/data_module.py
+++ b/data_modules/data_module.py
@@ -5,6 +5,7 @@ from torch.utils.data import random_split, DataLoader
 import numpy as np
 from torch.utils.data.sampler import SubsetRandomSampler
 from configs.DataConfig import DataConfig
+from .data_helpers import *
 
 
 class GraphDataModule(pl.LightningDataModule):
@@ -63,15 +64,27 @@ class GraphDataModule(pl.LightningDataModule):
 
     def train_dataloader(self):
         return DataLoader(
-            self.dataset, batch_size=self.batch_size, sampler=self.train_sampler
+            self.dataset,
+            batch_size=self.batch_size,
+            sampler=self.train_sampler,
+            collate_fn=collate_fn,
+            drop_last=True,
         )
 
     def val_dataloader(self):
         return DataLoader(
-            self.dataset, batch_size=self.batch_size, sampler=self.valid_sampler
+            self.dataset,
+            batch_size=self.batch_size,
+            sampler=self.valid_sampler,
+            collate_fn=collate_fn,
+            drop_last=True,
         )
 
     def test_dataloader(self):
         return DataLoader(
-            self.dataset, batch_size=self.batch_size, sampler=self.test_sampler
+            self.dataset,
+            batch_size=self.batch_size,
+            sampler=self.test_sampler,
+            collate_fn=collate_fn,
+            drop_last=True,
         )

--- a/data_modules/dataset.py
+++ b/data_modules/dataset.py
@@ -2,7 +2,7 @@
 
 import torch
 import pickle
-
+from .data_helpers import *
 from utils.helpers import *
 
 
@@ -11,23 +11,26 @@ class GraphDataset(torch.utils.data.Dataset):
         self,
         data_dir,
         mode,
+        load_all=True,
         transform=None,
         target_transform=None,
     ):
         self.dir = data_dir
         self.mode = mode
         if mode == "pickle":
-            self.data = data_dir
+            if load_all:
+                self.data = load_all_pickle(data_dir)
+            else:
+                self.data = data_dir
         else:
             self.data = load_all_data(data_dir)
         self.transform = transform
+        self.loaded = load_all
         self.seq_length = 9
         self.target_transform = target_transform
 
     def __len__(self):
-        return (
-            len(os.listdir(self.dir)) - self.seq_length - 1
-        )  # int(len(os.listdir(self.dir)) / self.seq_length)
+        return len(os.listdir(self.dir)) - self.seq_length - 1
 
     def get_pickle(self, name):
         with open(name, "rb") as pickle_file:
@@ -35,15 +38,19 @@ class GraphDataset(torch.utils.data.Dataset):
 
     def __getitem__(self, idx):
         if self.mode == "pickle":
-            timeline = [
-                self.get_pickle(
-                    self.data
-                    + "/"
-                    + str(idx + i)
-                    + ".pickle"  # str(idx * self.seq_length + i)
-                )
-                for i in range(self.seq_length)
-            ]
+            timeline = (
+                [
+                    self.get_pickle(
+                        self.data
+                        + "/"
+                        + str(idx + i)
+                        + ".pickle"  # str(idx * self.seq_length + i)
+                    )
+                    for i in range(self.seq_length)
+                ]
+                if not self.loaded
+                else self.data[idx : idx + self.seq_length]
+            )
         else:
             timeline = self.data[idx]
         sample = timeline[:-1]
@@ -52,4 +59,4 @@ class GraphDataset(torch.utils.data.Dataset):
             sample = self.transform(sample)
         if self.target_transform:
             label = self.target_transform(label)
-        return sample, label
+        return sample, label[-1]

--- a/layers/Discriminator.py
+++ b/layers/Discriminator.py
@@ -16,10 +16,11 @@ class Discriminator(nn.Module):
             ),
             nn.LeakyReLU(0.2),
             nn.Linear(
-                discriminator_config.hidden_size, discriminator_config.hidden_size / 2
+                discriminator_config.hidden_size,
+                int(discriminator_config.hidden_size / 2),
             ),
             nn.LeakyReLU(0.2),
-            nn.Linear(discriminator_config.hidden_size / 2, 1),
+            nn.Linear(int(discriminator_config.hidden_size / 2), 1),
             nn.Sigmoid(),
         )
 

--- a/layers/EdgeUpdate.py
+++ b/layers/EdgeUpdate.py
@@ -19,7 +19,9 @@ class EdgeUpdate(torch.nn.Module):
 
     def forward(
         self,
-        inputs: torch.Tensor,
+        node_fts: torch.Tensor,
+        edge_fts: torch.Tensor,
+        edges: torch.Tensor,
     ) -> torch.Tensor:
         """
         Args:
@@ -27,6 +29,7 @@ class EdgeUpdate(torch.nn.Module):
         Returns:
             edge_fts: updated edge features
         """
+        inputs = (node_fts, edge_fts, edges)
         node_fts, edge_fts, edges = inputs
 
         node_fts, edge_fts, edges = (

--- a/layers/GNBlock.py
+++ b/layers/GNBlock.py
@@ -79,9 +79,12 @@ class GNBlock(nn.Module):
             else None
         )
 
-    def forward(self, input):
-        node_fts, edge_fts, edges, adj = input
-
+    def forward(
+        self,
+        node_fts: torch.Tensor,
+        edge_fts: torch.Tensor,
+        edges: torch.Tensor,
+    ):
         if self.edge_update is not None:
             edge_fts = self.edge_update([node_fts, edge_fts, edges])
 

--- a/layers/LossModule.py
+++ b/layers/LossModule.py
@@ -1,0 +1,19 @@
+import torch
+import torch.nn as nn
+
+
+class LossModule(nn.Module):
+    def __init__(self, loss):
+        super(LossModule, self).__init__()
+        self.loss = loss
+
+    def forward(self, pred, target) -> torch.Tensor:
+        """
+        Args:
+            input: Output of Generator, represented via row-wise adjacency matrix (batch_size x num_nodes x num_nodes)
+            target: Ground truth adjacency matrix (batch_size x num_nodes x num_nodes)
+        """
+        batched_target_adj = target.reshape(-1, target.shape[-1] * target.shape[-1])
+        batched_predicted_adj = pred.reshape(-1, target.shape[-1] * target.shape[-1])
+
+        return self.loss(batched_predicted_adj, batched_target_adj)

--- a/layers/MultiHeadNodeAttention.py
+++ b/layers/MultiHeadNodeAttention.py
@@ -83,6 +83,7 @@ class MultiHeadNodeAttention(nn.Module):
                 dim=1,
             )
         elif self.head_agg_mode == "weighted_mean":
+            # TODO: Is nonlinear activation necessary here?
             node_ft_embeds = self.leaky_relu(
                 torch.mul(
                     node_attentions_var.unsqueeze(1).unsqueeze(1), node_ft_embeds

--- a/layers/NodeAttention.py
+++ b/layers/NodeAttention.py
@@ -98,6 +98,7 @@ class NodeAttentionHead(nn.Module):
         # Repeat the sum for each neighbor of the node
         node_attention_sum = node_attention_sum[edges_undirected[:, 0]]
 
+        # TODO: Is logsoftmax vs softmax?
         # Normalize attention scores by dividing each by neighborhood sum
         node_attention_norm = torch.log(node_attention / node_attention_sum)
 


### PR DESCRIPTION
Implements collate_fn to handle batching of data, since PyTorch's default collate_fn won't work on variable sized graph data.

collate_fn returns a list [batched_edges, batched_node_fts, batched_edge_fts, batched_graph_fts, batched_target]  where:

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;  **batched_edges** has dim (2, total number of edges in the batch),
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;  **batched_node_fts** has dim (total node number in the batch, node feature dim)
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;  **batched_edge_fts** has dim (total number of edges in the batch, edge feature dim)
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;  **batched_graph_fts** has dim (total number of graphs in the batch, graph feature dim)
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;  **batched_target** has dim (total number of nodes in the batch, max number of nodes in any single graph in the batch)

Since the task of the model is to predict the adjacency matrix, we can only train on graphs of fixed node size (with varying edge numbers). However, in the future, padding to max number of nodes can be done to fix this issue. 

**Note:** Loading all pickle files at init will create some overhead, but since we enable batching now training becomes much faster and the overhead is negligible. Also, passing batches of filenames doesn't make sense.